### PR TITLE
Add pagination to transaction list API

### DIFF
--- a/internal/handler/transaction_handler.go
+++ b/internal/handler/transaction_handler.go
@@ -56,7 +56,20 @@ func (h *TransactionHandler) GetByID(c *fiber.Ctx) error {
 }
 
 func (h *TransactionHandler) GetAll(c *fiber.Ctx) error {
-	trxs, err := h.service.GetAll(c.Context())
+	limitParam := c.Query("limit", "100")
+	offsetParam := c.Query("offset", "0")
+
+	limit, err := strconv.Atoi(limitParam)
+	if err != nil || limit <= 0 {
+		limit = 100
+	}
+
+	offset, err := strconv.Atoi(offsetParam)
+	if err != nil || offset < 0 {
+		offset = 0
+	}
+
+	trxs, err := h.service.GetAll(c.Context(), limit, offset)
 	if err != nil {
 		c.Locals("err", err)
 		return util.ErrorResponse(c, fiber.StatusInternalServerError, "Terjadi kesalahan")

--- a/internal/repository/transaction_repository.go
+++ b/internal/repository/transaction_repository.go
@@ -13,7 +13,10 @@ import (
 type TransactionRepository interface {
 	Create(ctx context.Context, tx *model.Transaction) error
 	GetByID(ctx context.Context, id int64) (*model.Transaction, error)
-	GetAll(ctx context.Context) ([]model.Transaction, error)
+	// GetAll returns a slice of transactions with pagination support.
+	// limit defines the maximum number of records to return.
+	// offset defines the starting point in the result set.
+	GetAll(ctx context.Context, limit, offset int) ([]model.Transaction, error)
 	Update(ctx context.Context, transaction *model.Transaction) error
 	Delete(ctx context.Context, id int64) error
 }
@@ -49,9 +52,9 @@ func (r *transactionRepository) GetByID(ctx context.Context, id int64) (*model.T
 	return &t, nil
 }
 
-func (r *transactionRepository) GetAll(ctx context.Context) ([]model.Transaction, error) {
-	query := `SELECT id, customer_id, transaction_at, transaction_amount FROM transactions`
-	rows, err := r.db.Query(ctx, query)
+func (r *transactionRepository) GetAll(ctx context.Context, limit, offset int) ([]model.Transaction, error) {
+	query := `SELECT id, customer_id, transaction_at, transaction_amount FROM transactions ORDER BY id LIMIT $1 OFFSET $2`
+	rows, err := r.db.Query(ctx, query, limit, offset)
 	if err != nil {
 		return nil, fmt.Errorf("error querying transactions: %w", err)
 	}

--- a/internal/service/transaction_service.go
+++ b/internal/service/transaction_service.go
@@ -11,7 +11,8 @@ import (
 type TransactionService interface {
 	Create(ctx context.Context, dto *model.CreateTransactionDTO) (*model.Transaction, error)
 	GetByID(ctx context.Context, id int64) (*model.Transaction, error)
-	GetAll(ctx context.Context) ([]model.Transaction, error)
+	// GetAll retrieves transactions with the given limit and offset.
+	GetAll(ctx context.Context, limit, offset int) ([]model.Transaction, error)
 	Update(ctx context.Context, id int64, dto *model.UpdateTransactionDTO) error
 	Delete(ctx context.Context, id int64) error
 }
@@ -47,8 +48,8 @@ func (s *transactionService) GetByID(ctx context.Context, id int64) (*model.Tran
 	return tx, nil
 }
 
-func (s *transactionService) GetAll(ctx context.Context) ([]model.Transaction, error) {
-	return s.repo.GetAll(ctx)
+func (s *transactionService) GetAll(ctx context.Context, limit, offset int) ([]model.Transaction, error) {
+	return s.repo.GetAll(ctx, limit, offset)
 }
 
 func (s *transactionService) Update(ctx context.Context, id int64, dto *model.UpdateTransactionDTO) error {


### PR DESCRIPTION
## Summary
- prevent huge responses from `/transactions` by adding limit & offset parameters
- update repository/service/handler implementations for pagination

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_684bcbeb31c483248fd58158242b2bdc